### PR TITLE
Display the version of any mods, plus a few fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ class ExampleModBind extends Module { // Replace the class name with a unique na
           bg: '', // if the bg is set to nothing, it will use the default bg
           icon: 'fnficon32', // path to icon (32x32)
           author: "the elusive my mod team", // name of the people who made the mod
+          version: "0.1.0",
           logo: '', // big logo for the mod.
           color: 0xFFB00B69, // color for the selection tab thingies
           bg_group: (group) -> { // for dynamic bgs, to add stuff you must do "group.add(myVar)"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ class ExampleModBind extends Module { // Replace the class name with a unique na
           bg: '', // if the bg is set to nothing, it will use the default bg
           icon: 'fnficon32', // path to icon (32x32)
           author: "the elusive my mod team", // name of the people who made the mod
-          version: "0.1.0",
+          version: "0.1.0", // version number, based on semantic versions
           logo: '', // big logo for the mod.
           color: 0xFFB00B69, // color for the selection tab thingies
           bg_group: (group) -> { // for dynamic bgs, to add stuff you must do "group.add(myVar)"

--- a/scripts/modules/InitBootstrap.hxc
+++ b/scripts/modules/InitBootstrap.hxc
@@ -83,9 +83,10 @@ class InitBootstrap extends Module {
 			description: "Manage mods you have downloaded in your mods folder.",
 			target: "BootStrapManager",
 			logo: '',
-      bg: '',
-      icon: 'modbootstrap-addons-menu-icon32',
-      author: "Burgerballs",
+			bg: '',
+			icon: 'modbootstrap-addons-menu-icon32',
+			author: "Burgerballs",
+			version: "0.4.1",
 			color: 0xFF000000,
 			bg_group: (group) -> {
 				return; // do nothing.
@@ -97,9 +98,10 @@ class InitBootstrap extends Module {
 			description: "Download Mods onto your mods folder.",
 			target: "ComingSoonState",
 			logo: '',
-      bg: '',
-      icon: 'modbootstrap-addons-menu-icon32',
-      author: "Burgerballs",
+			bg: '',
+			icon: 'modbootstrap-addons-menu-icon32',
+			author: "Burgerballs",
+			version: "0.4.1",
 			color: 0xFF000000,
 			bg_group: (group) -> {
 				return; // do nothing.
@@ -111,9 +113,10 @@ class InitBootstrap extends Module {
 			description: "Uh oh! Your tryin to kiss ur hot girlfriend, but her MEAN and EVIL dad is trying to KILL you! He's an ex-rockstar, the only way to get to his heart? The power of music...",
 			target: "BaseTitleState",
 			logo: 'base-game-logo',
-      bg: '',
-      icon: 'fnficon32',
-      author: "The Funkin' Crew",
+			bg: '',
+			icon: 'fnficon32',
+			author: "The Funkin' Crew",
+			version: "0.4.1", // convenience purposes, the same for all of the above
 			color: 0xFFff2b77,
 			bg_group: (group) -> {
 				return; // do nothing.

--- a/scripts/modules/api/BootStrapBinds.hxc
+++ b/scripts/modules/api/BootStrapBinds.hxc
@@ -5,10 +5,11 @@ typedef Bind = {
 	name:String, // name of your mod, `Save.instance.modOptions.get("ModBootstrap").selected_mod` will use this.
 	target:String, // target `ScriptedMusicBeatState` class name to open after `on_init`
 	bg:String, // path to the mod bg, if it is null, it will be set to the default.
-  icon:String, // path to the mod icon, if it is null, it will be set to the default. Advisable to be 32x32.
-  description:String, // Description of the mod.
-  logo:String, // path to the mod logo, used for the title in the middle, if null, it's replaced with a name.
-  author:String, // name of the ones who made the mod.
+	icon:String, // path to the mod icon, if it is null, it will be set to the default. Advisable to be 32x32.
+	description:String, // Description of the mod.
+	logo:String, // path to the mod logo, used for the title in the middle, if null, it's replaced with a name.
+	author:String, // name of the ones who made the mod.
+	version:String, // version number.
 	color:Int,
 	disclaimer:String,
 	bg_group:Null<(Dynamic)->Void>
@@ -34,9 +35,10 @@ class BootStrapBinds extends Module {
 			description: data.description,
 			target:     data.target,
 			bg:         data.bg,
-      icon:       data.icon,
-      logo:       data.logo,
-      author:     data.author,
+			icon:       data.icon,
+			logo:       data.logo,
+			author:     data.author,
+			version:    data.version,
 			color:      data.color,
 			disclaimer: data.disclaimer,
 			bg_group: data.bg_group,

--- a/scripts/states/BootStrapManager.hxc
+++ b/scripts/states/BootStrapManager.hxc
@@ -112,7 +112,7 @@ class BootStrapManager extends ScriptedMusicBeatState {
     var tooltipTextBG = new FlxSprite(320,720 - 48).makeGraphic(640, 48, 0xFF101010);
     add(tooltipTextBG);
 		// do da sexy text thing
-		tooltipText = new FlxText(328,720 - 46,640, "Press UP/DOWN to navigate.\nPress ACCEPT to toggle.\nPress ESC to restart the game.", 16);
+		tooltipText = new FlxText(328,720 - 46,640, "Press UP/DOWN to navigate.\nPress ACCEPT to toggle.\nPress ESC to exit to the ModBootstrap main menu.", 16);
 		tooltipText.setFormat('VCR OSD Mono', 14, 0xFFFFFFFF, 'center');
 		add(tooltipText);
 
@@ -121,15 +121,15 @@ class BootStrapManager extends ScriptedMusicBeatState {
 
   public function addMetadataInfo(modName,modTextTitle,modData,modRenderer) {
     modTextTitle.text = modData.title;
-    var modText:FlxText = new FlxText(8,34,0, modData.description, 16);
-    modText.setFormat('VCR OSD Mono', 16, 0xFFFFFFFF, 'left');
+    var modText:FlxText = new FlxText(8,34,0, modData.description, 12);
+    modText.setFormat('VCR OSD Mono', 12, 0xFFFFFFFF, 'left');
     modRenderer.add(modText);
     if (modText.fieldWidth >= 400) {
       modText.scale.x = 400 / modText.fieldWidth;
       modText.updateHitbox();
     }
-    var modText:FlxText = new FlxText(8,50,0, 'Licenced under: ' + modData.license, 16);
-    modText.setFormat('VCR OSD Mono', 16, 0xFFFFFFFF, 'left');
+    var modText:FlxText = new FlxText(8,46,0, 'Licensed under: ' + modData.license + "\nVersion: " + modData.mod_version, 12);
+    modText.setFormat('VCR OSD Mono', 12, 0xFFFFFFFF, 'left');
     modRenderer.add(modText);
 
     var modImage:FlxSprite = new FlxSprite(624 - 130,2).loadGraphic(returnGraphic('mods', modName, '_polymod_icon'));

--- a/scripts/states/BootStrapState.hxc
+++ b/scripts/states/BootStrapState.hxc
@@ -21,8 +21,8 @@ import funkin.ui.freeplay.CapsuleText;
 import openfl.net.FileReference;
 class BootStrapState extends ScriptedMusicBeatState {
 	var binds:Array<Dynamic>;
-  var cur_select:Float = 0.0; // current selected mod index, float for math reasons.
-  var mods_rendered:Array<FlxTypedSpriteGroup> = []; // This looks scary but i dont care nanna nanna boo boo!!
+	var cur_select:Float = 0.0; // current selected mod index, float for math reasons.
+	var mods_rendered:Array<FlxTypedSpriteGroup> = []; // This looks scary but i dont care nanna nanna boo boo!!
 	var mods_bg:Array<FlxTypedSpriteGroup> = []; // collection of sprites if a mod has any.
 	var intendedYs:Array<Float> = [];
 	var intendedHandY:Float;
@@ -41,7 +41,7 @@ class BootStrapState extends ScriptedMusicBeatState {
 	var descriptionTextBG:FlxSprite;
 	var descriptionText:FlxText;
 	var settings:Dynamic;
-	var optionHeight:Int = 48;
+	var optionHeight:Int = 56;
 
 	public function new() {
 		super();
@@ -111,8 +111,8 @@ class BootStrapState extends ScriptedMusicBeatState {
 		add(disclaimerText);
 
 		descriptionTextBG = new FlxSprite(0,0).makeGraphic(1,1, 0xFF000000);
-    descriptionTextBG.alpha = 0.6;
-    add(descriptionTextBG);
+		descriptionTextBG.alpha = 0.6;
+		add(descriptionTextBG);
 
 		descriptionText = new FlxText(360,540,1280 - 400, "Friday Night Funkin", 18);
 		descriptionText.text = "Uh oh! Your tryin to kiss ur hot girlfriend, but her MEAN and EVIL dad is trying to KILL you! He's an ex-rockstar, the only way to get to his heart? The power of music...";
@@ -121,16 +121,17 @@ class BootStrapState extends ScriptedMusicBeatState {
 		updateTextBG();
 		handleBinds();
 
-
 		var modSelectTextBG = new FlxSprite(0,0).makeGraphic(320, 56, 0xFF101010);
-    add(modSelectTextBG);
+    	add(modSelectTextBG);
+
 		// do da sexy text thing
 		var modSelectText:CapsuleText = new CapsuleText(60,10, "MOD SELECT", 56);
 		modSelectText.whiteText.setFormat('5by7', 36, 0xFFFFFFFF, 'center');
 		modSelectText.blurredText.setFormat('5by7', 36, 0xFF00ccff, 'center');
 		add(modSelectText);
 		var tooltipTextBG = new FlxSprite(0,720 - 48).makeGraphic(320, 48, 0xFF101010);
-    add(tooltipTextBG);
+    	add(tooltipTextBG);
+
 		// do da sexy text thing
 		var tooltipText:FlxText = new FlxText(8,720 - 46,320, "Press UP/DOWN to navigate.\nPress ACCEPT to enter.\nPress TAB to enter options.\nPress C to see mod credits.", 12);
 		tooltipText.setFormat('VCR OSD Mono', 11, 0xFFFFFFFF, 'left');
@@ -172,8 +173,12 @@ class BootStrapState extends ScriptedMusicBeatState {
 				var modTextAuthor:FlxText = new FlxText(4,24,0, 'By: "' + bind.author + '"', 14);
 				modTextAuthor.setFormat('VCR OSD Mono', 14, 0xFFFFFFFF, 'left');
 				modRenderer.add(modTextAuthor);
+
+				var verText:FlxText = new FlxText(4,36,0, bind.version, 14);
+				verText.setFormat('VCR OSD Mono', 14, 0xFFFFFFFF, 'left');
+				modRenderer.add(verText);
 			}
-			var modIcon:FlxSprite = new FlxSprite(312 - 36,optionHeight > 32 ? optionHeight / 8 : 0).loadGraphic(Paths.image(bind.icon));
+			var modIcon:FlxSprite = new FlxSprite(312 - 36, optionHeight > 32 ? optionHeight / 8 : 0).loadGraphic(Paths.image(bind.icon));
 			modRenderer.add(modIcon);
 			intendedYs.push(0);
 			columnHeight += optionHeight + 4;


### PR DESCRIPTION
Since there is going to be a Mod Downloader soon, I decided to make a pull request that first displays the versions of mods, based on the current state of the Mod Database.

The pull request addresses displaying the versions of most mods, both in the Bootstrap Loader and the Bootstrap Mod Manager. For mods that the Bootstrap can load into, the version is defined by a new variable within each mod's Bootstrap module, while mods that don't require the Bootstrap display the `mod_version` variable in their Polymod metadata for themselves instead. As stated before, some fixes were also included, such as making some of the scripts nicer to read and a more proper version of the tooltip in the Mod Manager.